### PR TITLE
Task 1 initial version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: bash
+
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - shellcheck
+
+script:
+ - make ci
+
+matrix:
+  fast_finish: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+default: check
+
+.PHONY: check ci
+
+check:
+	shellcheck $(shell find $(CURDIR)/script -iname "*.sh")
+
+ci: check

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# scripts-build-go
+# scripts-build-go [![Build Status](https://travis-ci.org/crucibuild/scripts-build-go.svg?branch=master)](https://travis-ci.org/crucibuild/scripts-build-go)
 Common Go build scripts

--- a/conf/gometalinter.json
+++ b/conf/gometalinter.json
@@ -1,0 +1,29 @@
+{
+    "Enable": [
+        "aligncheck",
+        "deadcode",
+        "errcheck",
+        "gas",
+        "goconst",
+        "gocyclo",
+        "golint",
+        "gotype",
+        "ineffassign",
+        "interfacer",
+        "megacheck",
+        "misspell",
+        "safesql",
+        "structcheck",
+        "unparam",
+        "varcheck"
+    ],
+    "Unused": [
+        "lll",
+        "dupl",
+        "goimports"
+    ],
+    "Exclude": [
+         "resources.go"
+    ],
+    "Deadline": "60s"
+}

--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,6 @@
+package main
+
+// Permits to go get repo
+func main() {
+	// Do nothing
+}

--- a/script/check.sh
+++ b/script/check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -xe
+
+SCRIPT_PATH="$( readlink -f "${BASH_SOURCE[0]}" )"
+SCRIPT_DIR="$( dirname "${SCRIPT_PATH}" )"
+
+go get -u github.com/alecthomas/gometalinter
+gometalinter --install --update
+gometalinter -j2 --config "${SCRIPT_DIR}/../conf/gometalinter.json" ./...

--- a/script/gen_coverage.sh
+++ b/script/gen_coverage.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+
+PROJECT="$(realpath --relative-to="$GOPATH/src" .)"
+
+go get golang.org/x/tools/cmd/cover
+go get github.com/go-playground/overalls
+"${GOPATH}/bin/overalls" -project="$PROJECT"

--- a/script/push_coverage.sh
+++ b/script/push_coverage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+
+go get github.com/mattn/goveralls
+"${GOPATH}/bin/goveralls" -coverprofile=overalls.coverprofile -service=travis-ci

--- a/script/resource.sh
+++ b/script/resource.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -xe
+
+usage()
+{
+    echo "$0 <OUT_FILE> <IN_FILES>"
+}
+
+if [ $# -lt 2 ]
+then
+    usage
+    exit 1
+fi
+
+OUT_FILE="$1"
+shift
+
+go get -v "github.com/omeid/go-resources/cmd/resources"
+resources -output="$OUT_FILE" -var="Resources" -trim="" "$@"


### PR DESCRIPTION
I created scripts for each common tasks which aren't done by a simple "go XXX" command.

I think that wrapping even basic calls will add complexity for literally no gain as these commands are basic enough. Having them in the Makefile generated by cookiecutter is enough.

Closes #1 